### PR TITLE
Fixed issue with `y` attr on `rect`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ git-seq
 
 (or, as gh suggested, "vigilant-octo-bassoon") a sequencer for github contribution history
 
+![demo](https://d17oy1vhnax1f7.cloudfront.net/items/0831263E2F2m2K2s1z3W/Screen%20Recording%202017-01-16%20at%2004.56%20PM.gif?v=3857eff5)
+
+make sure you have your sound up! (but not too up)
+
+### Running Locally
+
 ```
 git clone https://github.com/zhangoose/git-seq.git
 cd git-seq

--- a/app.py
+++ b/app.py
@@ -17,7 +17,7 @@ def play(username):
     curr_index = 0
 
     # for each `y=` attribute on each <rect>, an index mapping
-    y_trans = {0:0, 13:1, 26:2, 39:3, 52:4, 65:5, 78:6}
+    y_trans = {0:0, 12:1, 24:2, 36:3, 48:4, 60:5, 72:6}
 
     svg = soup.find('svg', class_='js-calendar-graph-svg')
     svg = str(svg).replace('\n', '')


### PR DESCRIPTION
### Changes
* changed the `y_trans` indexing for determining which `y` attrs determine M/T/W/Th/S/Su
* added a fun gif to the readme 

Not sure why this happened? 
![image](https://cloud.githubusercontent.com/assets/2905198/22000467/35a8fa78-dc0d-11e6-93e6-9f3d9f5c1a8f.png)

### Problem
After inspecting element on the contribution graph, I noticed that `y`s are nolonger using 0, 13, 26, etc.... but instead 0, 12, 24, etc....


### Thoughts & Notes
Can't think of why this numbering was changed, maybe it was because of the new year? And what date 2017 started on vs the date 2016 started on? 

### Better fixes? 
Better fix would be to put a grouping function for every 7 rectangles that pass by. This wasn't done before since before, the contribution graph would only go back 365 days

#### Old contribution graph

Taken from [this kid's blog](http://erik.io/blog/2016/04/01/how-github-contribution-graph-is-harmful/)

![image](https://cloud.githubusercontent.com/assets/2905198/22000549/b99cff64-dc0d-11e6-8c32-e740835a7ea1.png)

##### New contribution graph

![image](https://cloud.githubusercontent.com/assets/2905198/22000618/209c5282-dc0e-11e6-9745-805f5e129a93.png)

365 days ago was not January 10, 2016

### Conclusion
.... I guess this will do for now. Will continue to monitor this changing `y` thing. might just be missing something unbearably simple.


