### PR TITLE
Fixing another issue with the start index

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,7 +14,7 @@ def play(username):
 
     # instantiating an empty array of arrays for all the contributions
     to_play = [[] for i in range(54)] 
-    curr_index = 0
+    curr_index = -1
 
     # for each `y=` attribute on each <rect>, an index mapping
     y_trans = {0:0, 12:1, 24:2, 36:3, 48:4, 60:5, 72:6}
@@ -46,4 +46,4 @@ def form():
 
 
 if __name__ == "__main__":
-    app.run()
+    app.run(debug=True)

--- a/app.py
+++ b/app.py
@@ -46,4 +46,4 @@ def form():
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run()


### PR DESCRIPTION
Not sure why this didn't surface itself in the previous fix, but while trying to put this on heroku, found that we were starting the `to_play` dictionary on index `1` because the first `y` is 0. Might just be a thing that's happening today (since it's Monday). Might also be caused by github nolonger looking at the past 365 days for the contribution graph? 

Well, here is the fix for this issue if it continues tomorrow.